### PR TITLE
Benchmark executing queries with ConcreteEcdarBackend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ opt-level = 3
 tonic-build = "0.8.2"
 
 [dev-dependencies]
-criterion = "0.4.0"
+criterion = { version = "0.4.0", features = ["async_futures"] }
 
 [[bench]]
 name = "bench"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -69,12 +69,13 @@ fn not_refinement(c: &mut Criterion) {
 }
 
 fn send_query_same_components(c: &mut Criterion) {
+    let json = std::fs::read_to_string(format!("{}/Components/Machine.json", PATH)).unwrap();
     c.bench_function("send_query_same_components", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
             let backend = ConcreteEcdarBackend::default();
             let mut responses = vec![];
             for _ in 0..64 {
-                let request = create_query_request("determinism: Machine", 0);
+                let request = create_query_request(&json, "determinism: Machine", 0);
                 responses.push(backend.send_query(request));
             }
 
@@ -86,13 +87,14 @@ fn send_query_same_components(c: &mut Criterion) {
 }
 
 fn send_query_different_components(c: &mut Criterion) {
+    let json = std::fs::read_to_string(format!("{}/Components/Machine.json", PATH)).unwrap();
     c.bench_function("send_query_different_components", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
             let backend = ConcreteEcdarBackend::default();
             let mut responses = vec![];
 
             for hashvalue in 0..64 {
-                let request = create_query_request("determinism: Machine", hashvalue);
+                let request = create_query_request(&json, "determinism: Machine", hashvalue);
                 responses.push(backend.send_query(request));
             }
 
@@ -103,16 +105,14 @@ fn send_query_different_components(c: &mut Criterion) {
     });
 }
 
-fn create_query_request(query: &str, hash: u32) -> Request<QueryRequest> {
-    let json = std::fs::read_to_string(format!("{}/Components/Machine.json", PATH)).unwrap();
-
+fn create_query_request(json: &String, query: &str, hash: u32) -> Request<QueryRequest> {
     Request::new(QueryRequest {
         user_id: 0,
         query_id: 0,
         query: String::from(query),
         components_info: Some(ComponentsInfo {
             components: vec![Component {
-                rep: Some(Rep::Json(json)),
+                rep: Some(Rep::Json(json.clone())),
             }],
             components_hash: hash,
         }),

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,5 +1,19 @@
-use criterion::{criterion_group, criterion_main, Criterion};
-use reveaal::tests::refinement::Helper::json_refinement_check;
+use std::vec;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use reveaal::{
+    tests::refinement::Helper::json_refinement_check,
+    ProtobufServer::{
+        services::{
+            component::Rep, ecdar_backend_server::EcdarBackend, Component, ComponentsInfo,
+            QueryRequest,
+        },
+        ConcreteEcdarBackend,
+    },
+};
+use tonic::Request;
+
+use criterion::async_executor::FuturesExecutor;
 
 static PATH: &str = "samples/json/EcdarUniversity";
 
@@ -54,6 +68,46 @@ fn not_refinement(c: &mut Criterion) {
     bench_non_refinement(c, "Adm2 || Researcher <= Spec // Machine");
 }
 
-criterion_group!(benches, self_refinement, refinement, not_refinement);
+fn send_query_same_components(c: &mut Criterion) {
+    c.bench_function("send_query_same_components", |b| {
+        b.to_async(FuturesExecutor).iter(|| async {
+            let backend = ConcreteEcdarBackend::default();
+            let mut responses = vec![];
+            for _ in 0..64 {
+                let request = create_query_request("determinism: Machine");
+                responses.push(backend.send_query(request));
+            }
+
+            for response in responses {
+                _ = black_box(response.await);
+            }
+        });
+    });
+}
+
+fn create_query_request(query: &str) -> Request<QueryRequest> {
+    let json = std::fs::read_to_string(format!("{}/Components/Machine.json", PATH)).unwrap();
+
+    Request::new(QueryRequest {
+        user_id: 0,
+        query_id: 0,
+        query: String::from(query),
+        components_info: Some(ComponentsInfo {
+            components: vec![Component {
+                rep: Some(Rep::Json(json)),
+            }],
+            components_hash: 0,
+        }),
+        ignored_input_outputs: None,
+    })
+}
+
+criterion_group!(
+    benches,
+    self_refinement,
+    refinement,
+    not_refinement,
+    send_query_same_components
+);
 
 criterion_main!(benches);


### PR DESCRIPTION
We have created two benchmarks:
- Executing multiple queries that use the same components
- Executing multiple queries that use different components

This is intended to benchmark the effects of adding a component cache and executing the queries on a threadpool.

We also added a feature to criterion, which makes it able to bench async functions.