### PR TITLE
Add profiler to benches that outputs a flamegraph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ opt-level = 3
 tonic-build = "0.8.2"
 
 [dev-dependencies]
+pprof = { version = "0.10.1", features = ["flamegraph"] }
 criterion = { version = "0.4.0", features = ["async_futures"] }
 
 [[bench]]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -17,6 +17,9 @@ use criterion::async_executor::FuturesExecutor;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 
+mod flamegraph_profiler;
+use flamegraph_profiler::FlamegraphProfiler;
+
 static PATH: &str = "samples/json/EcdarUniversity";
 
 fn bench_refinement(c: &mut Criterion, query: &str) {
@@ -175,14 +178,16 @@ fn create_components(json: &Vec<String>) -> Vec<Component> {
         .collect()
 }
 
-criterion_group!(benches, self_refinement, refinement, not_refinement,);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(FlamegraphProfiler::new(100));
+    targets = self_refinement, refinement, not_refinement,
+}
 
-criterion_group!(
-    backend_bench,
-    send_query_same_components,
-    send_query_different_components,
-    send_expensive_query_same_components,
-    send_expensive_query_different_components,
-);
+criterion_group! {
+    name = backend_bench;
+    config = Criterion::default().with_profiler(FlamegraphProfiler::new(100));
+    targets = send_query_same_components, send_query_different_components, send_expensive_query_same_components, send_expensive_query_different_components
+}
 
 criterion_main!(benches, backend_bench);

--- a/benches/flamegraph_profiler.rs
+++ b/benches/flamegraph_profiler.rs
@@ -1,0 +1,39 @@
+use std::{fs::File, os::raw::c_int, path::Path};
+
+use criterion::profiler::Profiler;
+use pprof::ProfilerGuard;
+
+pub struct FlamegraphProfiler<'a> {
+    frequency: c_int,
+    active_profiler: Option<ProfilerGuard<'a>>,
+}
+
+impl<'a> FlamegraphProfiler<'a> {
+    pub fn new(frequency: c_int) -> Self {
+        FlamegraphProfiler {
+            frequency,
+            active_profiler: None,
+        }
+    }
+}
+
+impl<'a> Profiler for FlamegraphProfiler<'a> {
+    fn start_profiling(&mut self, _benchmark_id: &str, _benchmark_dir: &Path) {
+        self.active_profiler = Some(ProfilerGuard::new(self.frequency).unwrap());
+    }
+
+    fn stop_profiling(&mut self, _benchmark_id: &str, benchmark_dir: &Path) {
+        std::fs::create_dir_all(benchmark_dir).expect("Could not create benchmark directory");
+        let flamegraph_path = benchmark_dir.join("flamegraph.svg");
+        let flamegraph_file =
+            File::create(&flamegraph_path).expect("Could not create the flamegraph file");
+        self.active_profiler
+            .take()
+            .unwrap()
+            .report()
+            .build()
+            .unwrap()
+            .flamegraph(flamegraph_file)
+            .expect("Could not save the flamegraph")
+    }
+}


### PR DESCRIPTION
Benchmarks can now be profiled and a flamegraph will be outputted. The flamegraph is an interactive svg file.
The benchmarks still work as they used to but now we can profile them by running the command:
`cargo bench --bench benches -- --profile-time=5`
This will profile all benchmarks for 5 seconds each. The flamegraph can be found here:
`target/criterion/<bench_name>/profile/flamegraph.svg`

A flamegraph for the bench `Adm2 <= Adm2` can be seen below:
This example does not represent how it will work/look as github removes scripts from the svg
![flamegraph](https://user-images.githubusercontent.com/8753257/199197133-0fa62972-d56b-45e5-a7f1-6867ffac297f.svg)

I have not tested this on windows.
