### PR TITLE
Cleanup of threadpool benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,7 @@ criterion = { version = "0.4.0", features = ["async_futures"] }
 [[bench]]
 name = "bench"
 harness = false
+
+[[bench]]
+name = "threadpool_bench"
+harness = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,21 +1,7 @@
-use std::vec;
-
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use reveaal::{
     tests::refinement::Helper::json_refinement_check,
-    ProtobufServer::{
-        services::{
-            component::Rep, ecdar_backend_server::EcdarBackend, Component, ComponentsInfo,
-            QueryRequest,
-        },
-        ConcreteEcdarBackend,
-    },
 };
-use tonic::Request;
-
-use criterion::async_executor::FuturesExecutor;
-use futures::stream::FuturesUnordered;
-use futures::StreamExt;
 
 mod flamegraph_profiler;
 use flamegraph_profiler::FlamegraphProfiler;
@@ -73,121 +59,10 @@ fn not_refinement(c: &mut Criterion) {
     bench_non_refinement(c, "Adm2 || Researcher <= Spec // Machine");
 }
 
-fn send_expensive_query_same_components(c: &mut Criterion) {
-    let json = vec![
-        std::fs::read_to_string(format!("{}/Components/Administration.json", PATH)).unwrap(),
-        std::fs::read_to_string(format!("{}/Components/Researcher.json", PATH)).unwrap(),
-        std::fs::read_to_string(format!("{}/Components/Machine.json", PATH)).unwrap(),
-    ];
-    c.bench_function("send_expensive_query_same_components", |b| {
-        b.to_async(FuturesExecutor).iter(|| async {
-            let backend = ConcreteEcdarBackend::default();
-            let responses = (0..64)
-                .map(|_| {
-                    let request = create_query_request(
-                        &json,
-                        "determinism: Administration || Researcher || Machine",
-                        0,
-                    );
-                    backend.send_query(request)
-                })
-                .collect::<FuturesUnordered<_>>();
-
-            _ = black_box(responses.collect::<Vec<_>>().await);
-        });
-    });
-}
-
-fn send_expensive_query_different_components(c: &mut Criterion) {
-    let json = vec![
-        std::fs::read_to_string(format!("{}/Components/Administration.json", PATH)).unwrap(),
-        std::fs::read_to_string(format!("{}/Components/Researcher.json", PATH)).unwrap(),
-        std::fs::read_to_string(format!("{}/Components/Machine.json", PATH)).unwrap(),
-    ];
-    c.bench_function("send_expensive_query_different_components", |b| {
-        b.to_async(FuturesExecutor).iter(|| async {
-            let backend = ConcreteEcdarBackend::default();
-            let responses = (0..64)
-                .map(|hash| {
-                    let request = create_query_request(
-                        &json,
-                        "determinism: Administration || Researcher || Machine",
-                        hash,
-                    );
-                    backend.send_query(request)
-                })
-                .collect::<FuturesUnordered<_>>();
-
-            _ = black_box(responses.collect::<Vec<_>>().await);
-        });
-    });
-}
-
-fn send_query_same_components(c: &mut Criterion) {
-    let json = vec![std::fs::read_to_string(format!("{}/Components/Machine.json", PATH)).unwrap()];
-    c.bench_function("send_query_same_components", |b| {
-        b.to_async(FuturesExecutor).iter(|| async {
-            let backend = ConcreteEcdarBackend::default();
-            let responses = (0..64)
-                .map(|_| {
-                    let request = create_query_request(&json, "determinism: Machine", 0);
-                    backend.send_query(request)
-                })
-                .collect::<FuturesUnordered<_>>();
-
-            _ = black_box(responses.collect::<Vec<_>>().await);
-        });
-    });
-}
-
-fn send_query_different_components(c: &mut Criterion) {
-    let json = vec![std::fs::read_to_string(format!("{}/Components/Machine.json", PATH)).unwrap()];
-    c.bench_function("send_query_different_components", |b| {
-        b.to_async(FuturesExecutor).iter(|| async {
-            let backend = ConcreteEcdarBackend::default();
-            let responses = (0..64)
-                .map(|hash| {
-                    let request = create_query_request(&json, "determinism: Machine", hash);
-                    backend.send_query(request)
-                })
-                .collect::<FuturesUnordered<_>>();
-
-            _ = black_box(responses.collect::<Vec<_>>().await);
-        });
-    });
-}
-
-fn create_query_request(json: &Vec<String>, query: &str, hash: u32) -> Request<QueryRequest> {
-    Request::new(QueryRequest {
-        user_id: 0,
-        query_id: 0,
-        query: String::from(query),
-        components_info: Some(ComponentsInfo {
-            components: create_components(json),
-            components_hash: hash,
-        }),
-        ignored_input_outputs: None,
-    })
-}
-
-fn create_components(json: &Vec<String>) -> Vec<Component> {
-    json.into_iter()
-        .map(|json| Component {
-            rep: Some(Rep::Json(json.clone())),
-        })
-        .collect()
-}
-
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(FlamegraphProfiler::new(100));
     targets = self_refinement, refinement, not_refinement,
 }
 
-criterion_group! {
-    name = backend_bench;
-    config = Criterion::default().with_profiler(FlamegraphProfiler::new(100));
-    targets = send_query_same_components, send_query_different_components, send_expensive_query_same_components, send_expensive_query_different_components
-}
-
-criterion_main!(benches, backend_bench);
+criterion_main!(benches);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,7 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use reveaal::{
-    tests::refinement::Helper::json_refinement_check,
-};
+use reveaal::tests::refinement::Helper::json_refinement_check;
 
 mod flamegraph_profiler;
 use flamegraph_profiler::FlamegraphProfiler;

--- a/benches/threadpool_bench.rs
+++ b/benches/threadpool_bench.rs
@@ -18,6 +18,8 @@ use flamegraph_profiler::FlamegraphProfiler;
 
 static PATH: &str = "samples/json/EcdarUniversity";
 
+const NUM_OF_REQUESTS: u32 = 512;
+
 fn send_query_with_components(
     id: String,
     c: &mut Criterion,
@@ -28,7 +30,7 @@ fn send_query_with_components(
     c.bench_function(&id, |b| {
         b.to_async(FuturesExecutor).iter(|| async {
             let backend = ConcreteEcdarBackend::default();
-            let responses = (0..512)
+            let responses = (0..NUM_OF_REQUESTS)
                 .map(|hash| {
                     let request = create_query_request(
                         &components,

--- a/benches/threadpool_bench.rs
+++ b/benches/threadpool_bench.rs
@@ -1,0 +1,88 @@
+use std::vec;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use reveaal::{
+    ProtobufServer::{
+        services::{
+            component::Rep, ecdar_backend_server::EcdarBackend, Component, ComponentsInfo,
+            QueryRequest,
+        },
+        ConcreteEcdarBackend,
+    },
+};
+use tonic::Request;
+
+use criterion::async_executor::FuturesExecutor;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+
+static PATH: &str = "samples/json/EcdarUniversity";
+
+fn send_query_with_components(id: String, c: &mut Criterion, components: &Vec<String>, query: &String, active_cache: bool) {
+    c.bench_function(&id, |b| {
+        b.to_async(FuturesExecutor).iter(|| async {
+            let backend = ConcreteEcdarBackend::default();
+            let responses = (0..512)
+                .map(|hash| {
+                    let request = create_query_request(
+                        &components,
+                        &query,
+                        if active_cache 
+                        {
+                            0
+                        } 
+                        else {
+                            hash
+                        },
+                    );
+                    backend.send_query(request)
+                })
+                .collect::<FuturesUnordered<_>>();
+
+            _ = black_box(responses.collect::<Vec<_>>().await);
+        });
+    });
+}
+
+fn create_query_request(json: &Vec<String>, query: &str, hash: u32) -> Request<QueryRequest> {
+    Request::new(QueryRequest {
+        user_id: 0,
+        query_id: 0,
+        query: String::from(query),
+        components_info: Some(ComponentsInfo {
+            components: create_components(json),
+            components_hash: hash,
+        }),
+        ignored_input_outputs: None,
+    })
+}
+
+fn create_components(json: &Vec<String>) -> Vec<Component> {
+    json.into_iter()
+        .map(|json| Component {
+            rep: Some(Rep::Json(json.clone())),
+        })
+        .collect()
+}
+
+fn threadpool_cache(c: &mut Criterion){
+    let json = vec![
+        std::fs::read_to_string(format!("{}/Components/Administration.json", PATH)).unwrap(),
+        std::fs::read_to_string(format!("{}/Components/Researcher.json", PATH)).unwrap(),
+        std::fs::read_to_string(format!("{}/Components/Machine.json", PATH)).unwrap(),
+    ];
+    let expensive_query = String::from("determinism: Administration || Researcher || Machine");
+    let cheap_query = String::from("determinism: Machine");
+
+    send_query_with_components(String::from("Expensive queries with identical models"), c, &json, &expensive_query, true);
+    send_query_with_components(String::from("Expensive queries with different models"), c, &json, &expensive_query, false);
+    send_query_with_components(String::from("Cheap queries with identical models"), c, &json, &cheap_query, true);
+    send_query_with_components(String::from("Cheap queries with different models"), c, &json, &cheap_query, false);
+}
+
+criterion_group!(
+    backend_bench,
+    threadpool_cache,
+);
+
+criterion_main!(backend_bench);

--- a/benches/threadpool_bench.rs
+++ b/benches/threadpool_bench.rs
@@ -13,6 +13,9 @@ use criterion::async_executor::FuturesExecutor;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 
+mod flamegraph_profiler;
+use flamegraph_profiler::FlamegraphProfiler;
+
 static PATH: &str = "samples/json/EcdarUniversity";
 
 fn send_query_with_components(
@@ -101,6 +104,10 @@ fn threadpool_cache(c: &mut Criterion) {
     );
 }
 
-criterion_group!(backend_bench, threadpool_cache,);
+criterion_group! {
+    name = backend_bench;
+    config = Criterion::default().with_profiler(FlamegraphProfiler::new(100));
+    targets = threadpool_cache
+}
 
 criterion_main!(backend_bench);


### PR DESCRIPTION
- Changed the benchmark to be a single function with parameters that is called multiple times, which emulates the 4 previously used functions.
- Made sure all the benchmarks parse the same number of components to ensure consistency.