### PR TITLE
Group 16 - User eviction from cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ env_logger = { version = "0.9.0", optional = true }
 chrono = { version = "0.4.22", optional = true }
 crossbeam-channel = "0.5.6"
 num_cpus = "1.13.1"
+lru = "0.8.1"
 
 # Enable optimizations for EDBM in debug mode, but not for our code:
 [profile.dev.package.edbm]

--- a/src/DataReader/component_loader.rs
+++ b/src/DataReader/component_loader.rs
@@ -14,11 +14,24 @@ use std::sync::{Arc, RwLock};
 type ComponentsMap = HashMap<String, Component>;
 
 /// A struct used for caching the models.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct ModelCache {
     // TODO: A concurrent hashmap may be faster to use and cause less prone to locking, but is not part of the standard library.
     cache: Arc<RwLock<HashMap<u32, Arc<ComponentsMap>>>>,
-    user_cache: LruCache<u32, u32>
+    user_cache: Arc<RwLock<LruCache<u32, u32>>>,
+}
+
+impl Default for ModelCache
+{
+    fn default() -> Self {
+        Self { 
+            cache: Default::default(), 
+            user_cache: Arc::new(
+                RwLock::new(
+                    LruCache::<u32, u32>::new(
+                        NonZeroUsize::new(100).unwrap()))) 
+        }
+    }
 }
 
 impl ModelCache {

--- a/src/ProtobufServer/ecdar_backend.rs
+++ b/src/ProtobufServer/ecdar_backend.rs
@@ -50,7 +50,7 @@ impl EcdarBackend for ConcreteEcdarBackend {
         _request: Request<()>,
     ) -> Result<Response<UserTokenResponse>, Status> {
         let id = self.num.fetch_add(1, Ordering::SeqCst);
-        let token_response = UserTokenResponse{ user_id: id };
+        let token_response = UserTokenResponse { user_id: id };
         Result::Ok(Response::new(token_response))
     }
 

--- a/src/ProtobufServer/ecdar_backend.rs
+++ b/src/ProtobufServer/ecdar_backend.rs
@@ -6,6 +6,7 @@ use crate::ProtobufServer::services::{
     SimulationStepResponse, UserTokenResponse,
 };
 use futures::FutureExt;
+use std::collections::HashMap;
 use std::panic::UnwindSafe;
 use tonic::{Request, Response, Status};
 
@@ -15,6 +16,7 @@ use super::threadpool::ThreadPool;
 pub struct ConcreteEcdarBackend {
     thread_pool: ThreadPool,
     model_cache: ModelCache,
+    num: i32,
 }
 
 async fn catch_unwind<T, O>(future: T) -> Result<O, Status>
@@ -46,7 +48,9 @@ impl EcdarBackend for ConcreteEcdarBackend {
         &self,
         _request: Request<()>,
     ) -> Result<Response<UserTokenResponse>, Status> {
-        unimplemented!();
+        let id = self.num + 1;
+        let token_response = UserTokenResponse{ user_id: id };
+        Result::Ok(Response::new(token_response))
     }
 
     async fn send_query(

--- a/src/ProtobufServer/ecdar_backend.rs
+++ b/src/ProtobufServer/ecdar_backend.rs
@@ -6,7 +6,6 @@ use crate::ProtobufServer::services::{
     SimulationStepResponse, UserTokenResponse,
 };
 use futures::FutureExt;
-use std::collections::HashMap;
 use std::panic::UnwindSafe;
 use std::sync::atomic::{AtomicI32, Ordering};
 use tonic::{Request, Response, Status};

--- a/src/ProtobufServer/ecdar_requests/send_query.rs
+++ b/src/ProtobufServer/ecdar_requests/send_query.rs
@@ -52,10 +52,7 @@ impl ConcreteEcdarBackend {
                         .flat_map(parse_components_if_some)
                         .flatten()
                         .collect::<Vec<Component>>();
-                    let components = create_components(
-                        parsed_components,
-                        query_request.settings.unwrap_or(DEFAULT_SETTINGS),
-                    );
+                    let components = create_components(parsed_components);
                     model_cache.insert_model(
                         user_id,
                         components_info.components_hash,

--- a/src/ProtobufServer/ecdar_requests/send_query.rs
+++ b/src/ProtobufServer/ecdar_requests/send_query.rs
@@ -43,22 +43,27 @@ impl ConcreteEcdarBackend {
         let query = parse_query(&query_request)?;
         let user_id = query_request.user_id;
 
-        let mut component_container = match model_cache.get_model(user_id, components_info.components_hash) {
-            Some(model) => model,
-            None => {
-                let mut parsed_components = vec![];
+        let mut component_container =
+            match model_cache.get_model(user_id, components_info.components_hash) {
+                Some(model) => model,
+                None => {
+                    let mut parsed_components = vec![];
 
-                for proto_component in proto_components {
-                    let components = parse_components_if_some(proto_component)?;
-                    for component in components {
-                        parsed_components.push(component);
+                    for proto_component in proto_components {
+                        let components = parse_components_if_some(proto_component)?;
+                        for component in components {
+                            parsed_components.push(component);
+                        }
                     }
-                }
 
-                let components = create_components(parsed_components);
-                model_cache.insert_model(user_id, components_info.components_hash, Arc::new(components))
-            }
-        };
+                    let components = create_components(parsed_components);
+                    model_cache.insert_model(
+                        user_id,
+                        components_info.components_hash,
+                        Arc::new(components),
+                    )
+                }
+            };
 
         if query_request.ignored_input_outputs.is_some() {
             return Err(Status::unimplemented(

--- a/src/ProtobufServer/ecdar_requests/send_query.rs
+++ b/src/ProtobufServer/ecdar_requests/send_query.rs
@@ -41,8 +41,9 @@ impl ConcreteEcdarBackend {
         let components_info = query_request.components_info.as_ref().unwrap();
         let proto_components = &components_info.components;
         let query = parse_query(&query_request)?;
+        let user_id = query_request.user_id;
 
-        let mut component_container = match model_cache.get_model(components_info.components_hash) {
+        let mut component_container = match model_cache.get_model(user_id, components_info.components_hash) {
             Some(model) => model,
             None => {
                 let mut parsed_components = vec![];
@@ -55,7 +56,7 @@ impl ConcreteEcdarBackend {
                 }
 
                 let components = create_components(parsed_components);
-                model_cache.insert_model(components_info.components_hash, Arc::new(components))
+                model_cache.insert_model(user_id, components_info.components_hash, Arc::new(components))
             }
         };
 

--- a/src/ProtobufServer/ecdar_requests/send_query.rs
+++ b/src/ProtobufServer/ecdar_requests/send_query.rs
@@ -64,7 +64,8 @@ impl ConcreteEcdarBackend {
                     model_cache.insert_model(
                         user_id,
                         components_info.components_hash,
-                        Arc::new(components))
+                        Arc::new(components),
+                    )
                 }
             };
 


### PR DESCRIPTION
The cache is now separated by user id.
Changed the cache to be an LRU (Least Recently Used) cache.
This allows users to be evicted once the cache is full. (Default right now is max 100 cached users)

The cache will automatically evict the least recently used user when inserting new users in the cache.

The RwLock has been changed to a mutex, this means only 1 thread can read it at a time. We have tested the benchmarks and the similar performance suggests that this is not an issue.