### PR TITLE
Add cache size and threadpool threads cli arguments

### DIFF
--- a/src/DataReader/component_loader.rs
+++ b/src/DataReader/component_loader.rs
@@ -37,6 +37,19 @@ impl Default for ModelCache {
 }
 
 impl ModelCache {
+    /// A Method that creates a new cache with a given size limit.
+    ///
+    /// # Arguments
+    ///
+    /// * `cache_size` - A number representing the number of users that can be cached simultaneusly.
+    pub fn new(cache_size: usize) -> Self {
+        Self {
+            cache: Arc::new(Mutex::new(LruCache::<i32, ComponentTuple>::new(
+                NonZeroUsize::new(cache_size).unwrap(),
+            ))),
+        }
+    }
+
     /// A Method that returns the model from the cache.
     ///
     /// # Arguments

--- a/src/ProtobufServer/ecdar_backend.rs
+++ b/src/ProtobufServer/ecdar_backend.rs
@@ -19,6 +19,16 @@ pub struct ConcreteEcdarBackend {
     num: AtomicI32,
 }
 
+impl ConcreteEcdarBackend {
+    pub fn new(thread_count: usize, cache_size: usize) -> Self {
+        ConcreteEcdarBackend {
+            thread_pool: ThreadPool::new(thread_count),
+            model_cache: ModelCache::new(cache_size),
+            num: AtomicI32::new(1),
+        }
+    }
+}
+
 async fn catch_unwind<T, O>(future: T) -> Result<O, Status>
 where
     T: UnwindSafe + futures::Future<Output = Result<O, Status>>,

--- a/src/ProtobufServer/server.rs
+++ b/src/ProtobufServer/server.rs
@@ -5,7 +5,11 @@ use log::info;
 use tokio::runtime;
 use tonic::transport::Server;
 
-pub fn start_grpc_server_with_tokio(ip_endpoint: &str) -> Result<(), Box<dyn std::error::Error>> {
+pub fn start_grpc_server_with_tokio(
+    ip_endpoint: &str,
+    cache_size: usize,
+    thread_number: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
     //For information on switching to a multithreaded server see:
     //https://docs.rs/tokio/1.12.0/tokio/runtime/index.html#multi-thread-scheduler
     let single_threaded_runtime = runtime::Builder::new_current_thread()
@@ -13,15 +17,23 @@ pub fn start_grpc_server_with_tokio(ip_endpoint: &str) -> Result<(), Box<dyn std
         .enable_io()
         .build()?;
 
-    single_threaded_runtime.block_on(async { start_grpc_server(ip_endpoint).await })
+    single_threaded_runtime
+        .block_on(async { start_grpc_server(ip_endpoint, cache_size, thread_number).await })
 }
 
-async fn start_grpc_server(ip_endpoint: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn start_grpc_server(
+    ip_endpoint: &str,
+    cache_size: usize,
+    thread_number: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
     info!("Starting grpc server on '{}'", ip_endpoint.trim());
 
     Server::builder()
         .http2_keepalive_interval(Some(Duration::from_secs(120)))
-        .add_service(EcdarBackendServer::new(ConcreteEcdarBackend::default()))
+        .add_service(EcdarBackendServer::new(ConcreteEcdarBackend::new(
+            thread_number,
+            cache_size,
+        )))
         .serve(ip_endpoint.trim().parse()?)
         .await?;
 

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -31,9 +31,20 @@ args:
           long: clock-reduction-level
           required: false
           takes_value: true
-          #    - checkInputOutput:
-#        short: c
-#        long: checkInputOutput
-#        help: returns extra ouputs which are present on the left side and vise versa inputs
-#        required: false
-#        takes_value: false
+    - cache-size:
+          short: cs
+          long: cache-size
+          required: false
+          takes_value: true
+          default_value: 100
+    - thread-number:
+          short: tn
+          long: thread-number
+          required: false
+          takes_value: true
+#    - checkInputOutput:
+#          short: c
+#          long: checkInputOutput
+#          help: returns extra ouputs which are present on the left side and vise versa inputs
+#          required: false
+#          takes_value: false

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     setup_logger().unwrap();
 
     if let Some(ip_endpoint) = matches.value_of("endpoint") {
-        start_grpc_server_with_tokio(ip_endpoint)?;
+        let thread_count: usize = match matches.value_of("thread_number") {
+            Some(num_of_threads) => num_of_threads
+                .parse()
+                .expect("Could not parse the input for the number of threads"),
+            None => num_cpus::get(),
+        };
+        let cache_count: usize = matches
+            .value_of("cache_size")
+            .unwrap()
+            .parse()
+            .expect("Could not parse input for the cache_size");
+
+        start_grpc_server_with_tokio(ip_endpoint, cache_count, thread_count)?;
     } else {
         start_using_cli(&matches);
     }


### PR DESCRIPTION
Added the following cli arguments:
- `--cache-size <size>` Specify the maximum size of the cache (default: 100)
- `--thread-number <amount>` Specify the amount of threads to use in the thread pool (default: number of logical cores)