### PR TITLE
Group16 multithread determinism bench

### DIFF
--- a/benches/threadpool_bench.rs
+++ b/benches/threadpool_bench.rs
@@ -105,6 +105,27 @@ fn threadpool_cache(c: &mut Criterion) {
         &cheap_query,
         false,
     );
+
+    let bigJson = vec![
+        std::fs::read_to_string(format!("{}/Components/Administration.json", PATH)).unwrap(),
+        std::fs::read_to_string(format!("{}/Components/Researcher.json", PATH)).unwrap(),
+        std::fs::read_to_string(format!("{}/Components/Machine.json", PATH)).unwrap(),
+        std::fs::read_to_string(format!("{}/Components/Adm2.json", PATH)).unwrap(),
+        std::fs::read_to_string(format!("{}/Components/Machine1.json", PATH)).unwrap(),
+        std::fs::read_to_string(format!("{}/Components/Machine2.json", PATH)).unwrap(),
+        std::fs::read_to_string(format!("{}/Components/Machine3.json", PATH)).unwrap(),
+    ];
+
+    let very_expensive = String::from("determinism: Administration || Researcher || Machine || Adm2 || Machine1 || Machine2 || Machine3");
+
+    send_query_with_components(
+        String::from("Determinism multithread bench"),
+        c,
+        &bigJson,
+        &very_expensive,
+        true,
+    );
+
 }
 
 criterion_group! {

--- a/benches/threadpool_bench.rs
+++ b/benches/threadpool_bench.rs
@@ -111,12 +111,11 @@ fn threadpool_cache(c: &mut Criterion) {
         std::fs::read_to_string(format!("{}/Components/Researcher.json", PATH)).unwrap(),
         std::fs::read_to_string(format!("{}/Components/Machine.json", PATH)).unwrap(),
         std::fs::read_to_string(format!("{}/Components/Adm2.json", PATH)).unwrap(),
-        std::fs::read_to_string(format!("{}/Components/Machine1.json", PATH)).unwrap(),
         std::fs::read_to_string(format!("{}/Components/Machine2.json", PATH)).unwrap(),
         std::fs::read_to_string(format!("{}/Components/Machine3.json", PATH)).unwrap(),
     ];
 
-    let very_expensive = String::from("determinism: Administration || Researcher || Machine || Adm2 || Machine1 || Machine2 || Machine3");
+    let very_expensive = String::from("determinism: Administration || Researcher || Machine || Adm2 || Machine2 || Machine3");
 
     send_query_with_components(
         String::from("Determinism multithread bench"),

--- a/benches/threadpool_bench.rs
+++ b/benches/threadpool_bench.rs
@@ -62,18 +62,15 @@ fn send_determinism_query_with_components(c: &mut Criterion)
     c.bench_function("Determinism multithread bench", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
             let backend = ConcreteEcdarBackend::default();
-            let responses = (0..1)
-                .map(|hash| {
-                    let request = create_query_request(
-                        &big_model,
-                        &very_expensive,
-                        hash,
-                    );
-                    backend.send_query(request)
-                })
-                .collect::<FuturesUnordered<_>>();
-
-            _ = black_box(responses.collect::<Vec<_>>().await);
+            for _ in 0..NUM_OF_REQUESTS {
+                let request = create_query_request(
+                    &big_model,
+                    &very_expensive,
+                    0,
+                );
+                let request = backend.send_query(request);
+                _ = black_box(request.await);
+            }
         });
     });
 }

--- a/benches/threadpool_bench.rs
+++ b/benches/threadpool_bench.rs
@@ -77,6 +77,25 @@ fn threadpool_cache(c: &mut Criterion) {
     let expensive_query = String::from("determinism: Administration || Researcher || Machine");
     let cheap_query = String::from("determinism: Machine");
 
+    let big_model = vec![
+        std::fs::read_to_string(format!("{}/Components/Administration.json", PATH)).unwrap(),
+        std::fs::read_to_string(format!("{}/Components/Researcher.json", PATH)).unwrap(),
+        std::fs::read_to_string(format!("{}/Components/Machine.json", PATH)).unwrap(),
+        std::fs::read_to_string(format!("{}/Components/Adm2.json", PATH)).unwrap(),
+        std::fs::read_to_string(format!("{}/Components/Machine2.json", PATH)).unwrap(),
+        std::fs::read_to_string(format!("{}/Components/Machine3.json", PATH)).unwrap(),
+    ];
+
+    let very_expensive = String::from("determinism: Administration || Researcher || Machine || Adm2 || Machine2 || Machine3");
+
+    send_query_with_components(
+        String::from("Determinism multithread bench"),
+        c,
+        &big_model,
+        &very_expensive,
+        true,
+    );
+
     send_query_with_components(
         String::from("Expensive queries with identical models"),
         c,
@@ -106,24 +125,6 @@ fn threadpool_cache(c: &mut Criterion) {
         false,
     );
 
-    let bigJson = vec![
-        std::fs::read_to_string(format!("{}/Components/Administration.json", PATH)).unwrap(),
-        std::fs::read_to_string(format!("{}/Components/Researcher.json", PATH)).unwrap(),
-        std::fs::read_to_string(format!("{}/Components/Machine.json", PATH)).unwrap(),
-        std::fs::read_to_string(format!("{}/Components/Adm2.json", PATH)).unwrap(),
-        std::fs::read_to_string(format!("{}/Components/Machine2.json", PATH)).unwrap(),
-        std::fs::read_to_string(format!("{}/Components/Machine3.json", PATH)).unwrap(),
-    ];
-
-    let very_expensive = String::from("determinism: Administration || Researcher || Machine || Adm2 || Machine2 || Machine3");
-
-    send_query_with_components(
-        String::from("Determinism multithread bench"),
-        c,
-        &bigJson,
-        &very_expensive,
-        true,
-    );
 
 }
 

--- a/benches/threadpool_bench.rs
+++ b/benches/threadpool_bench.rs
@@ -46,8 +46,7 @@ fn send_query_with_components(
     });
 }
 
-fn send_determinism_query_with_components(c: &mut Criterion)
-{
+fn send_determinism_query_with_components(c: &mut Criterion) {
     let big_model = vec![
         std::fs::read_to_string(format!("{}/Components/Administration.json", PATH)).unwrap(),
         std::fs::read_to_string(format!("{}/Components/Researcher.json", PATH)).unwrap(),
@@ -57,17 +56,15 @@ fn send_determinism_query_with_components(c: &mut Criterion)
         std::fs::read_to_string(format!("{}/Components/Machine3.json", PATH)).unwrap(),
     ];
 
-    let very_expensive = String::from("determinism: Administration || Researcher || Machine || Adm2 || Machine2 || Machine3");
+    let very_expensive = String::from(
+        "determinism: Administration || Researcher || Machine || Adm2 || Machine2 || Machine3",
+    );
 
     c.bench_function("Determinism multithread bench", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
             let backend = ConcreteEcdarBackend::default();
             for _ in 0..NUM_OF_REQUESTS {
-                let request = create_query_request(
-                    &big_model,
-                    &very_expensive,
-                    0,
-                );
+                let request = create_query_request(&big_model, &very_expensive, 0);
                 let request = backend.send_query(request);
                 _ = black_box(request.await);
             }
@@ -134,8 +131,6 @@ fn threadpool_cache(c: &mut Criterion) {
         &cheap_query,
         false,
     );
-
-
 }
 
 criterion_group! {


### PR DESCRIPTION
This benchmarks aims to test the performance of our determinism multithread solution in #146.

It gives it the best possible scenario where all threads are available when the query runs (they are awaited individually).

With this bench we can conclude that even with a large model and thereby an expensive determinism query we see a ~10% loss in performance on our machine.